### PR TITLE
add library retry

### DIFF
--- a/robotframework/requirements.txt
+++ b/robotframework/requirements.txt
@@ -5,3 +5,4 @@ robotframework-httplibrary==0.4.2
 pyvirtualdisplay==0.2
 robotframework-pabot==0.43
 robotframework-pageobjectlibrary==1.0.0b2
+retry


### PR DESCRIPTION
Testeissä pitää mukautua käyttöliittymän hitauteen. Yksi tapa on laittaa tuloksen tarkistavat funktiokutsut jonkinlaiseen retry-luuppiin. PageObject/python -testeihin retry-dekoraattori https://pypi.python.org/pypi/retry/0.9.2 vaikuttaa moiseen varsin näppärältä. Lisätään se siis imageen.